### PR TITLE
Add role binding to the template definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,9 @@ To prevent _Prometheus_ from discovering an application, its pod must be annotat
 ## Demo (OpenShift)
 
 1. Create a new project and import `prometheus-grafana-discovery.yml`
-2. Add `prom-discover-pods` role to `prometheus` service account (you can do it either from the web console, section _Resources / Membership_, or via command line `oc adm policy add-role-to-user prom-discover-pods -z prometheus --role-namespace=your_namespace` - just replace _your_namespace_)
-3. Open Grafana: after a while you should see the Prometheus datasource and dashboard being added
-4. Add to project `examples/wfapp.yml`
-5. Check Grafana: after a while you should see a JVM dashboard being added
+2. Open Grafana: after a while you should see the Prometheus datasource and dashboard being added
+3. Add to project `examples/wfapp.yml`
+4. Check Grafana: after a while you should see a JVM dashboard being added
 
 ### Scenario with OpenTracing
 

--- a/prometheus-grafana-discovery-dev.yml
+++ b/prometheus-grafana-discovery-dev.yml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Template
 metadata:
   name: prometheus-grafana-discovery
+parameters:
+- description: The namespace where to deploy the services.
+  name: NAMESPACE
+  required: true
+
 objects:
 
 ####### ROLE AND SERVICE ACCOUNT #######
@@ -20,6 +25,17 @@ objects:
   kind: ServiceAccount
   metadata:
     name: prometheus
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: prom-discover-pods
+  roleRef:
+    name: prom-discover-pods
+    namespace: "${NAMESPACE}"
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: "${NAMESPACE}"
 
 ####### PROMETHEUS #######
 - apiVersion: v1

--- a/prometheus-grafana-discovery.yml
+++ b/prometheus-grafana-discovery.yml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Template
 metadata:
   name: prometheus-grafana-discovery
+parameters:
+- description: The namespace where to deploy the services.
+  name: NAMESPACE
+  required: true
+
 objects:
 
 ####### ROLE AND SERVICE ACCOUNT #######
@@ -20,6 +25,17 @@ objects:
   kind: ServiceAccount
   metadata:
     name: prometheus
+- apiVersion: v1
+  kind: RoleBinding
+  metadata:
+    name: prom-discover-pods
+  roleRef:
+    name: prom-discover-pods
+    namespace: "${NAMESPACE}"
+  subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: "${NAMESPACE}"
 
 ####### PROMETHEUS #######
 - apiVersion: v1


### PR DESCRIPTION
This avoids invoking the 'oc adm' CLI although it requires to pass the
current namespace as a parameter when launching the app.

Not sure if you think it is a improvement, feel free to merge or reject ;-)